### PR TITLE
Fixes for instructions to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ GL_VERSION_3_1
 ### Linux
 In order to compile the program, the following Debian packages has to be installed.
 ```
-apt-get install install libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libsdl2-dev libfmt-dev libeigen3-dev libglew-dev libbz2-dev libzip-dev libfmt-dev binutils-dev
+apt-get install libyaml-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev libsdl2-dev libfmt-dev libeigen3-dev libglew-dev libbz2-dev libzip-dev libfmt-dev binutils-dev
 ```
 
 ## License


### PR DESCRIPTION
Add two fixes to the `apt-get` command to be able to compile:

1) Fixed an erroneous keyword `install` in the command, as `install` was there twice
2) Add `libyaml-dev` to the package list, which the project requires (otherwise the compile fails with `ld` not being able to recognize `-lyaml` as an option)